### PR TITLE
Warpinator 1.8.3, gnome runtime 45.

### DIFF
--- a/org.x.Warpinator.json
+++ b/org.x.Warpinator.json
@@ -1,7 +1,7 @@
 {
    "app-id": "org.x.Warpinator",
    "runtime": "org.gnome.Platform",
-   "runtime-version": "44",
+   "runtime-version": "45",
    "sdk": "org.gnome.Sdk",
    "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"
@@ -31,26 +31,10 @@
             {
                "type": "git",
                "url": "https://github.com/linuxmint/warpinator.git",
-               "commit": "896a0aea4e97f76adb72729050c776ed6a86de6d"
+               "commit": "3eb3ff994fc33a7891c79a4ce4e5090997db2677"
             }
          ],
          "modules": [
-         {
-               "name":"protobuf",
-               "cleanup":[
-                  "protoc",
-                  "/bin",
-                  "/doc",
-                  "/lib/plugins"
-               ],
-               "sources":[
-                  {
-                     "type":"archive",
-                     "url":"https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protobuf-cpp-3.21.12.tar.gz",
-                     "sha256":"4eab9b524aa5913c6fffb20b2a8abf5ef7f95a80bc0701f3a6dbb4c607f73460"
-                  }
-               ]
-            },
             "python3-modules.json",
             {
                "name": "python-xapp",
@@ -74,8 +58,8 @@
                   {
                      "type": "git",
                      "url": "https://github.com/linuxmint/xapp.git",
-                     "tag": "2.4.3",
-                     "commit": "c0658ed67e0998e053de25108fedca4718165c4a"
+                     "tag": "2.8.2",
+                     "commit": "97ce8df48a198b374aa74c68543ce6c0d79b61e8"
                   }
                ]
             }

--- a/python3-modules.json
+++ b/python3-modules.json
@@ -4,34 +4,6 @@
     "build-commands": [],
     "modules": [
         {
-            "name": "python3-grpcio",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"grpcio==1.44.0\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/65/75/8b706e1170e2c7b6242b1675259e47986bb4fc490f29387989a965972e6e/grpcio-1.44.0.tar.gz",
-                    "sha256": "4bae1c99896045d3062ab95478411c8d5a52cb84b91a1517312629fa6cfeb50e"
-                }
-            ]
-        },
-        {
-            "name": "python3-protobuf",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"protobuf==4.21.12\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/ba/dd/f8a01b146bf45ac12a829bbc599e6590aa6a6849ace7d28c42d77041d6ab/protobuf-4.21.12.tar.gz",
-                    "sha256": "7cd532c4566d0e6feafecc1059d04c7915aec8e182d1cf7adee8b24ef1e2e6ab"
-                }
-            ]
-        },
-        {
             "name": "python3-setproctitle",
             "buildsystem": "simple",
             "build-commands": [
@@ -46,26 +18,30 @@
             ]
         },
         {
-            "name": "python3-zeroconf",
+            "name": "python3-ifaddr",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"zeroconf==0.39.4\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"ifaddr\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/9c/1f/19ebc343cc71a7ffa78f17018535adc5cbdd87afb31d7c34874680148b32/ifaddr-0.2.0-py3-none-any.whl",
+                    "sha256": "085e0305cfe6f16ab12d72e2024030f5d52674afad6911bb1eee207177b8a748"
+                }
+            ]
+        },
+        {
+            "name": "python3-async_timeout",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"async_timeout\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/d6/c1/8991e7c5385b897b8c020cdaad718c5b087a6626d1d11a23e1ea87e325a7/async_timeout-4.0.2-py3-none-any.whl",
                     "sha256": "8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/9c/1f/19ebc343cc71a7ffa78f17018535adc5cbdd87afb31d7c34874680148b32/ifaddr-0.2.0-py3-none-any.whl",
-                    "sha256": "085e0305cfe6f16ab12d72e2024030f5d52674afad6911bb1eee207177b8a748"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/3f/ff/a8d7faaa3573b6e4c775cacbf911a0afbcb4928ce71b3de43119227a396a/zeroconf-0.39.4-py3-none-any.whl",
-                    "sha256": "d60eae9e9c99d1a168ce9ff9de7e7398c23754a0c2004ded230f8d529c5260a0"
                 }
             ]
         },
@@ -260,6 +236,36 @@
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/ed/35/a31aed2993e398f6b09a790a181a7927eb14610ee8bbf02dc14d31677f1c/packaging-23.0-py3-none-any.whl",
                     "sha256": "714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2"
+                }
+            ]
+        },
+        {
+            "name": "python3-qrcode",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"qrcode\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/30/35/ad6d4c5a547fe9a5baf85a9edbafff93fc6394b014fab30595877305fa59/qrcode-7.4.2.tar.gz",
+                    "sha256": "9dd969454827e127dbd93696b20747239e6d540e082937c90f14ac95b30f5845"
+                }
+            ],
+            "modules": [
+                {
+                    "name": "python3-pypng",
+                    "buildsystem": "simple",
+                    "build-commands": [
+                        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pypng\" --no-build-isolation"
+                    ],
+                    "sources": [
+                        {
+                            "type": "file",
+                            "url": "https://files.pythonhosted.org/packages/3e/b9/3766cc361d93edb2ce81e2e1f87dd98f314d7d513877a342d31b30741680/pypng-0.20220715.0-py3-none-any.whl",
+                            "sha256": "4a43e969b8f5aaafb2a415536c1a8ec7e341cd6a3f957fd5b5f32a4cfeed902c"
+                        }
+                    ]
                 }
             ]
         }


### PR DESCRIPTION
- Remove grpcio and protobuf builds from recipe (bundled with Warpinator now)
- Add python qrcode, async_timeout, ifaddr, pypng.
- Bump gnome runtime from 44->45.