### PR TITLE
Warpinator 2.0.3

### DIFF
--- a/0001-python-3.13-be-compatible-with-socket-ipv6-changes.patch
+++ b/0001-python-3.13-be-compatible-with-socket-ipv6-changes.patch
@@ -1,0 +1,75 @@
+From e6572f68806922e98222dd829a5fa060205c16d2 Mon Sep 17 00:00:00 2001
+From: Michael Webster <miketwebster@gmail.com>
+Date: Thu, 15 Jan 2026 10:17:43 -0500
+Subject: [PATCH] python 3.13: be compatible with socket ipv6 changes.
+
+---
+ src/remote_registration.py | 20 +++++++++++++++++---
+ src/util.py                |  4 +++-
+ 2 files changed, 20 insertions(+), 4 deletions(-)
+
+diff --git a/src/remote_registration.py b/src/remote_registration.py
+index 2f0275cf..2f419f7b 100644
+--- a/src/remote_registration.py
++++ b/src/remote_registration.py
+@@ -14,6 +14,15 @@ import util
+ import prefs
+ import config
+ 
++def get_ipv6_addr_tuple(addr, port):
++    if '%' in addr:
++        ip_part, scope_name = addr.split('%', 1)
++        scope_id = socket.if_nametoindex(scope_name)
++    else:
++        ip_part = addr
++        scope_id = 0
++    return (ip_part, port, 0, scope_id)
++
+ class RegRequest():
+     def __init__(self, ident, hostname, ip_info, port, auth_port, api_version):
+         self.api_version = api_version
+@@ -142,10 +151,12 @@ class Request():
+         remote_ip, _, ip_version = self.ip_info.get_usable_ip()
+ 
+         try:
+-            ip = remote_ip if ip_version == socket.AF_INET else "[%s]" % (remote_ip,)
+             server_sock = socket.socket(ip_version, socket.SOCK_DGRAM)
+             server_sock.settimeout(5.0)
+-            server_sock.sendto(REQUEST, (ip, self.port))
++            if ip_version == socket.AF_INET6:
++                server_sock.sendto(REQUEST, get_ipv6_addr_tuple(remote_ip, self.port))
++            else:
++                server_sock.sendto(REQUEST, (remote_ip, self.port))
+ 
+             reply, addr = server_sock.recvfrom(2000)
+ 
+@@ -182,7 +193,10 @@ class RegistrationServer_v1():
+             try:
+                 server_sock = socket.socket(ip_version, socket.SOCK_DGRAM)
+                 server_sock.settimeout(1.0)
+-                server_sock.bind((local_ip, self.port))
++                if ip_version == socket.AF_INET6:
++                    server_sock.bind(get_ipv6_addr_tuple(local_ip, self.port))
++                else:
++                    server_sock.bind((local_ip, self.port))
+             except socket.error as e:
+                 logging.critical("Could not create udp socket for cert requests: %s" % str(e))
+                 return
+diff --git a/src/util.py b/src/util.py
+index 7fb73909..ef237632 100644
+--- a/src/util.py
++++ b/src/util.py
+@@ -243,7 +243,9 @@ class InterfaceInfo():
+                 pass
+         if self.ip6:
+             try:
+-                blist.append(socket.inet_pton(GLib.SYSDEF_AF_INET6, self.ip6_address))
++                # Strip scope ID suffix if present (e.g., %eth0)
++                ip6_clean = self.ip6_address.split('%')[0] if '%' in self.ip6_address else self.ip6_address
++                blist.append(socket.inet_pton(GLib.SYSDEF_AF_INET6, ip6_clean))
+             except:
+                 pass
+ 
+-- 
+2.52.0
+

--- a/org.x.Warpinator.json
+++ b/org.x.Warpinator.json
@@ -1,11 +1,8 @@
 {
    "app-id": "org.x.Warpinator",
    "runtime": "org.gnome.Platform",
-   "runtime-version": "45",
+   "runtime-version": "49",
    "sdk": "org.gnome.Sdk",
-   "sdk-extensions": [
-        "org.freedesktop.Sdk.Extension.rust-stable"
-    ],
    "command": "warpinator",
    "finish-args": [
       "--share=ipc",
@@ -30,9 +27,13 @@
          "sources": [
             {
                "type": "git",
-               "tag": "1.8.6",
+               "tag": "2.0.3",
                "url": "https://github.com/linuxmint/warpinator.git",
-               "commit": "34413b665559c96f8ccc4bff5856d180e02777f6"
+               "commit": "d51681b2f580c4cad13d9c59af40a2952401d195"
+            },
+            {
+               "type": "patch",
+               "path": "0001-python-3.13-be-compatible-with-socket-ipv6-changes.patch"
             }
          ],
          "modules": [
@@ -44,7 +45,8 @@
                   {
                      "type": "git",
                      "url": "https://github.com/linuxmint/python-xapp.git",
-                     "commit": "052da5e56e3ca2e4c5f2bf905b66e316289ffd1d"
+                     "tag": "3.0.2",
+                     "commit": "83bf6f48ebf7314ae2be6450b7987f0422816f54"
                   }
                ]
             },
@@ -53,14 +55,14 @@
                "buildsystem": "meson",
                "config-opts": [
                   "-Dapp-lib-only=true",
-                  "-Dpy-overrides-dir=/app/lib/python3.10/site-packages/gi/overrides"
+                  "-Dpy-overrides-dir=/app/lib/python3.13/site-packages/gi/overrides"
                ],
                "sources": [
                   {
                      "type": "git",
                      "url": "https://github.com/linuxmint/xapp.git",
-                     "tag": "2.8.5",
-                     "commit": "3c85263447770597aa6e6d26b21bffba67b81186"
+                     "tag": "3.2.2",
+                     "commit": "913b2a2b441ec24daf3aa92e2863cc40e1c43650"
                   }
                ]
             }
@@ -70,7 +72,6 @@
    "cleanup": [
       "/bin/wheel",
       "/include",
-      "/lib/debug/source",
       "/lib/pkgconfig",
       "/share/gir-1.0",
       "/share/vala",

--- a/python3-modules.json
+++ b/python3-modules.json
@@ -12,8 +12,15 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/b5/47/ac709629ddb9779fee29b7d10ae9580f60a4b37e49bce72360ddf9a79cdc/setproctitle-1.3.2.tar.gz",
-                    "sha256": "b9fb97907c830d260fa0658ed58afd48a86b2b88aac521135c352ff7fd3477fd"
+                    "url": "https://files.pythonhosted.org/packages/87/ed/0a4f00315bc02510395b95eec3d4aa77c07192ee79f0baae77ea7b9603d8/setproctitle-1.3.7-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl",
+                    "sha256": "0564a936ea687cd24dffcea35903e2a20962aa6ac20e61dd3a207652401492dd",
+                    "only-arches": ["x86_64"]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/fc/e4/adf3c4c0a2173cb7920dc9df710bcc67e9bcdbf377e243b7a962dc31a51a/setproctitle-1.3.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "a5d1cb3f81531f0eb40e13246b679a1bdb58762b170303463cb06ecc296f26d0",
+                    "only-arches": ["aarch64"]
                 }
             ]
         },
@@ -32,111 +39,6 @@
             ]
         },
         {
-            "name": "python3-async_timeout",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"async_timeout\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/d6/c1/8991e7c5385b897b8c020cdaad718c5b087a6626d1d11a23e1ea87e325a7/async_timeout-4.0.2-py3-none-any.whl",
-                    "sha256": "8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"
-                }
-            ]
-        },
-        {
-            "name": "python3-setuptools_scm",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"setuptools_scm\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/ed/35/a31aed2993e398f6b09a790a181a7927eb14610ee8bbf02dc14d31677f1c/packaging-23.0-py3-none-any.whl",
-                    "sha256": "714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/0b/fc/8781442def77b0aa22f63f266d4dadd486ebc0c5371d6290caf4320da4b7/setuptools-67.6.1-py3-none-any.whl",
-                    "sha256": "e728ca814a823bf7bf60162daf9db95b93d532948c4c0bea762ce62f60189078"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/1d/66/8f42c941be949ef2b22fe905d850c794e7c170a526023612aad5f3a121ad/setuptools_scm-7.1.0-py3-none-any.whl",
-                    "sha256": "73988b6d848709e2af142aa48c986ea29592bbcfca5375678064708205253d8e"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl",
-                    "sha256": "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl",
-                    "sha256": "fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"
-                }
-            ]
-        },
-        {
-            "name": "python3-typing_extensions",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"typing_extensions\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl",
-                    "sha256": "fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"
-                }
-            ]
-        },
-        {
-            "name": "python3-semantic_version",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"semantic_version\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl",
-                    "sha256": "de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177"
-                }
-            ]
-        },
-        {
-            "name": "python3-setuptools_rust",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"setuptools_rust\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl",
-                    "sha256": "de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/0b/fc/8781442def77b0aa22f63f266d4dadd486ebc0c5371d6290caf4320da4b7/setuptools-67.6.1-py3-none-any.whl",
-                    "sha256": "e728ca814a823bf7bf60162daf9db95b93d532948c4c0bea762ce62f60189078"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/ef/da/dca8f90986325abe3027a5e3af5e12ce1d78eeb664a11971b2e7e703b9e3/setuptools_rust-1.5.2-py3-none-any.whl",
-                    "sha256": "8eb45851e34288f2296cd5ab9e924535ac1757318b730a13fe6836867843f206"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl",
-                    "sha256": "fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"
-                }
-            ]
-        },
-        {
             "name": "python3-cffi",
             "buildsystem": "simple",
             "build-commands": [
@@ -145,45 +47,39 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/2b/a8/050ab4f0c3d4c1b8aaa805f70e26e84d0e27004907c5b8ecc1d31815f92a/cffi-1.15.1.tar.gz",
-                    "sha256": "d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"
+                    "url": "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz",
+                    "sha256": "44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl",
-                    "sha256": "8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"
+                    "url": "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl",
+                    "sha256": "e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934"
                 }
             ]
         },
         {
             "name": "python3-cryptography",
-            "build-options": {
-                "append-path": "/usr/lib/sdk/rust-stable/bin",
-                "env": {
-                    "CARGO_HOME": "/run/build/python3-cryptography/cargo",
-                    "CARGO_NET_OFFLINE": "true"
-                }
-            },
             "buildsystem": "simple",
             "build-commands": [
                 "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"cryptography\" --no-build-isolation"
             ],
             "sources": [
-                "cargo-sources.json",
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/2b/a8/050ab4f0c3d4c1b8aaa805f70e26e84d0e27004907c5b8ecc1d31815f92a/cffi-1.15.1.tar.gz",
-                    "sha256": "d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"
+                    "url": "https://files.pythonhosted.org/packages/b1/07/40fe09ce96b91fc9276a9ad272832ead0fddedcba87f1190372af8e3039c/cryptography-44.0.0-cp37-abi3-manylinux_2_28_x86_64.whl",
+                    "sha256": "3c672a53c0fb4725a29c303be906d3c1fa99c32f58abe008a82705f9ee96f40b",
+                    "only-arches": ["x86_64"]
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/15/d9/c679e9eda76bfc0d60c9d7a4084ca52d0631d9f24ef04f818012f6d1282e/cryptography-40.0.1.tar.gz",
-                    "sha256": "2803f2f8b1e95f614419926c7e6f55d828afc614ca5ed61543877ae668cc3472"
+                    "url": "https://files.pythonhosted.org/packages/98/65/13d9e76ca19b0ba5603d71ac8424b5694415b348e719db277b5edc985ff5/cryptography-44.0.0-cp37-abi3-manylinux_2_28_aarch64.whl",
+                    "sha256": "761817a3377ef15ac23cd7834715081791d4ec77f9297ee694ca1ee9c2c7e5eb",
+                    "only-arches": ["aarch64"]
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl",
-                    "sha256": "8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"
+                    "url": "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl",
+                    "sha256": "e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934"
                 }
             ]
         },
@@ -196,18 +92,15 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/a7/22/27582568be639dfe22ddb3902225f91f2f17ceff88ce80e4db396c8986da/PyNaCl-1.5.0.tar.gz",
-                    "sha256": "8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba"
+                    "url": "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl",
+                    "sha256": "8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c",
+                    "only-arches": ["x86_64"]
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/2b/a8/050ab4f0c3d4c1b8aaa805f70e26e84d0e27004907c5b8ecc1d31815f92a/cffi-1.15.1.tar.gz",
-                    "sha256": "d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl",
-                    "sha256": "8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"
+                    "url": "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87",
+                    "only-arches": ["aarch64"]
                 }
             ]
         },
@@ -215,27 +108,34 @@
             "name": "python3-netifaces",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"netifaces\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"netifaces-plus\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/a6/91/86a6eac449ddfae239e93ffc1918cf33fd9bab35c04d1e963b311e347a73/netifaces-0.11.0.tar.gz",
-                    "sha256": "043a79146eb2907edf439899f262b3dfe41717d34124298ed281139a8b93ca32"
+                    "url": "https://files.pythonhosted.org/packages/ee/3f/993a07484ced542775c2ac9247975024023d490e1f022af06a88ceedcf76/netifaces_plus-0.12.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl",
+                    "sha256": "7ecf121658ce50ce8359b7a8761bb96d785980026e56a8a4bb219c6f1cab25db",
+                    "only-arches": ["x86_64"]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/96/2d/f5cdedfbde43a9e173cc7d94dbfccf0469a83b895d044fe098604c91dc56/netifaces_plus-0.12.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "46c37b0112c74cf6d99f23cf368147c163873d36ac20687a1cefb9e7fe16a66c",
+                    "only-arches": ["aarch64"]
                 }
             ]
         },
         {
-            "name": "python3-packaging",
+            "name": "python3-typing_extensions",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"packaging\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"typing_extensions\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/ed/35/a31aed2993e398f6b09a790a181a7927eb14610ee8bbf02dc14d31677f1c/packaging-23.0-py3-none-any.whl",
-                    "sha256": "714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2"
+                    "url": "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl",
+                    "sha256": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
                 }
             ]
         },


### PR DESCRIPTION
- Bump to org.gnome.Platform 49
- libxapp 3.2.2
- python-xapp 3.0.2
- setproctitle 1.3.7
- cryptography 44.0
- pynacl 1.6.2
- netifaces -> netifaces-plus 0.12.5 (temporary till netifaces is removed).